### PR TITLE
Aanpassing selecteer kenmerken

### DIFF
--- a/R/selecteerKenmerkenInOpname.R
+++ b/R/selecteerKenmerkenInOpname.R
@@ -125,20 +125,20 @@ selecteerKenmerkenInOpname <-
             ]
         )
 
-      if(nrow(Resultaat) > 0){
+      if (nrow(Resultaat) > 0) {
 
         Resultaat <- Resultaat %>%
-        left_join(
-          SubStatusberekening,
-          by = c("Rijnr")
-        ) %>%
-        mutate(
-          Rijnr = NULL
-        ) %>%
-        filter(
-          .data$Status == TRUE
-        ) %>%
-        distinct()
+          left_join(
+            SubStatusberekening,
+            by = c("Rijnr")
+          ) %>%
+          mutate(
+            Rijnr = NULL
+          ) %>%
+          filter(
+            .data$Status == TRUE
+          ) %>%
+          distinct()
 
       }
 

--- a/R/selecteerKenmerkenInOpname.R
+++ b/R/selecteerKenmerkenInOpname.R
@@ -102,6 +102,7 @@ selecteerKenmerkenInOpname <-
 
     if (!identical(SubAnalyseVariabele, character(0)) &
         SubAnalyseVariabele == "bedekking") {
+
       Resultaat <- Resultaat %>%
         mutate(
           RefMin = SubRefMin,
@@ -124,7 +125,9 @@ selecteerKenmerkenInOpname <-
             ]
         )
 
-      Resultaat <- Resultaat %>%
+      if(nrow(Resultaat) > 0){
+
+        Resultaat <- Resultaat %>%
         left_join(
           SubStatusberekening,
           by = c("Rijnr")
@@ -136,6 +139,8 @@ selecteerKenmerkenInOpname <-
           .data$Status == TRUE
         ) %>%
         distinct()
+
+      }
 
     } else {
       stop(

--- a/inst/tests/testthat/test_berekenLSVIbasis_2330bu_v3.R
+++ b/inst/tests/testthat/test_berekenLSVIbasis_2330bu_v3.R
@@ -29,12 +29,17 @@ describe("berekenLSVIbasis 2330_bu versie 3", {
           Data_habitat,
           Data_voorwaarden,
           Data_soortenKenmerken
-        ) %>%
+        )
+
+    resultaat_berekend_vw <- resultaat_berekend[[3]] %>%
       select(Habitattype, Versie, Criterium, Indicator, Voorwaarde, Waarde)
 
     expect_equal(
-      resultaat_berekend,
-      Resultaat
+      resultaat_berekend_vw
+        ,
+      Resultaat %>%
+        select(Habitattype, Versie, Criterium, Indicator, Voorwaarde, Waarde) %>%
+        mutate(Waarde = as.character(Waarde))
     )
   })
 })

--- a/inst/tests/testthat/test_berekenLSVIbasis_2330bu_v3.R
+++ b/inst/tests/testthat/test_berekenLSVIbasis_2330bu_v3.R
@@ -1,0 +1,41 @@
+context("test bereken waarde voor voorwaarden van 2330_bu versie 3")
+
+library(readr)
+library(dplyr)
+library(rlang)
+
+Data_habitat <-
+    read_csv2(
+      system.file("vbdata/data_habitat2330_bu.csv", package = "LSVI"),
+      col_types = list(col_character(), col_character(), col_character())
+    )
+Data_voorwaarden <-
+    read_csv2(system.file("vbdata/data_voorwaarden2330_bu.csv", package = "LSVI"))
+Data_soortenKenmerken <-
+    read_csv2(
+      system.file("vbdata/data_soortenKenmerken2330_bu.csv", package = "LSVI")
+    )
+
+Resultaat <- read_csv2(system.file("vbdata/resultaat2330_bu.csv", package = "LSVI"))
+
+describe("berekenLSVIbasis 2330_bu versie 3", {
+
+  it("waarden van voorwaarden correct berekend", {
+    skip_on_cran()
+
+    resultaat_berekend <- berekenLSVIbasis(
+          Versie = "Versie 3",
+          Kwaliteitsniveau = "1",
+          Data_habitat,
+          Data_voorwaarden,
+          Data_soortenKenmerken
+        ) %>%
+      select(Habitattype, Versie, Criterium, Indicator, Voorwaarde, Waarde)
+
+    expect_equal(
+      resultaat_berekend,
+      Resultaat
+    )
+  })
+})
+

--- a/inst/vbdata/data_habitat2330_bu.csv
+++ b/inst/vbdata/data_habitat2330_bu.csv
@@ -1,2 +1,2 @@
-"";"ID";"Habitattype";"TypePlot"
-"1";55058;"2330_bu";"vegetatieopname"
+"ID";"Habitattype";"TypePlot"
+55058;"2330_bu";"vegetatieopname"

--- a/inst/vbdata/data_habitat2330_bu.csv
+++ b/inst/vbdata/data_habitat2330_bu.csv
@@ -1,0 +1,2 @@
+"";"ID";"Habitattype";"TypePlot"
+"1";55058;"2330_bu";"vegetatieopname"

--- a/inst/vbdata/data_soortenKenmerken2330_bu.csv
+++ b/inst/vbdata/data_soortenKenmerken2330_bu.csv
@@ -1,0 +1,8 @@
+"";"ID";"Kenmerk";"Waarde";"Vegetatielaag";"TypeKenmerk";"Type";"Invoertype";"Eenheid"
+"1";55058;"Calluna vulgaris (L.) Hull";2;"kruidlaag";"Soort_Latijn";"Percentage";NA;"%"
+"2";55058;"Festuca filiformis Pourr.";1;"kruidlaag";"Soort_Latijn";"Percentage";NA;"%"
+"3";55058;"Pinus sylvestris L.";1;"kruidlaag";"Soort_Latijn";"Percentage";NA;"%"
+"4";55058;"Quercus robur L.";1;"kruidlaag";"Soort_Latijn";"Percentage";NA;"%"
+"5";55058;"Campylopus introflexus";40;"moslaag";"Soort_Latijn";"Percentage";NA;"%"
+"6";55058;"Dicranella species";1;"moslaag";"Soort_Latijn";"Percentage";NA;"%"
+"7";55058;"Hypnum jutlandicum";1;"moslaag";"Soort_Latijn";"Percentage";NA;"%"

--- a/inst/vbdata/data_soortenKenmerken2330_bu.csv
+++ b/inst/vbdata/data_soortenKenmerken2330_bu.csv
@@ -4,5 +4,5 @@
 "3";55058;"Pinus sylvestris L.";1;"kruidlaag";"Soort_Latijn";"Percentage";NA;"%"
 "4";55058;"Quercus robur L.";1;"kruidlaag";"Soort_Latijn";"Percentage";NA;"%"
 "5";55058;"Campylopus introflexus";40;"moslaag";"Soort_Latijn";"Percentage";NA;"%"
-"6";55058;"Dicranella species";1;"moslaag";"Soort_Latijn";"Percentage";NA;"%"
+"6";55058;"Dicranella";1;"moslaag";"Soort_Latijn";"Percentage";NA;"%"
 "7";55058;"Hypnum jutlandicum";1;"moslaag";"Soort_Latijn";"Percentage";NA;"%"

--- a/inst/vbdata/data_voorwaarden2330_bu.csv
+++ b/inst/vbdata/data_voorwaarden2330_bu.csv
@@ -1,0 +1,6 @@
+"";"Habitattype";"Criterium";"Indicator";"Voorwaarde";"ID";"Waarde";"Type";"Invoertype";"Eenheid"
+"1";"2330";"Structuur";"korstmosvegetaties";"bedekking korstmosvegetaties";55058;"62.5";"Percentage";NA;"%"
+"2";"2330";"Structuur";"horizontale structuur";"aantal ontwikkelingsstadia";55058;"3";"Geheel getal";NA;NA
+"3";"2330";"Verstoring";"verbossing";"bedekking verbossing";55058;"25";"Percentage";NA;"%"
+"4";"2330";"Structuur";"horizontale structuur";"bedekking open vegetaties";55058;"100";"Percentage";NA;"%"
+"5";"2330";"Structuur";"naakte bodem";"bedekking open zand";55058;"0";"Percentage";NA;"%"

--- a/inst/vbdata/resultaat2330_bu.csv
+++ b/inst/vbdata/resultaat2330_bu.csv
@@ -1,0 +1,7 @@
+"";"Habitattype";"Versie";"Criterium";"Indicator";"Voorwaarde";"Waarde"
+"1";"2330_bu";"Versie 3";"Structuur";"horizontale structuur";"bedekking open vegetaties";"100"
+"2";"2330_bu";"Versie 3";"Structuur";"naakte bodem";"bedekking open zand";"0"
+"3";"2330_bu";"Versie 3";"Vegetatie";"sleutelsoorten";"aantal sleutelsoorten";"0"
+"4";"2330_bu";"Versie 3";"Verstoring";"invasieve exoten";"bedekking invasieve exoten";"40"
+"5";"2330_bu";"Versie 3";"Verstoring";"verbossing";"bedekking verbossing";"25"
+"6";"2330_bu";"Versie 3";"Verstoring";"vergrassing";"bedekking vergrassing";"1"


### PR DESCRIPTION
in geval van voorwaarde met subanalysevariabele = bedekking (bv. aantal sleutelsoorten: aantal talrijk) worden eerst de sleutelsoorten geselecteerd en vervolgens de sleutelsoorten waarvoor de status = TRUE (bedekking >= talrijk). De status wordt via join aan de soort gehangen en op basis van de status kan dan een verdere selectie gebeuren. Maar als er geen sleutelsoorten zijn kan de join niet uitgevoerd worden en krijgt men een error. Vandaar bijkomende code toegevoegd om dit te verhelpen.