### PR TITLE
change code om error te vermijden

### DIFF
--- a/R/combinerenVerschilscore.R
+++ b/R/combinerenVerschilscore.R
@@ -40,7 +40,13 @@ combinerenVerschilscore <-
     for (i in seq_along(VoorwaardeID)) {
       Formule <- gsub(VoorwaardeID[i], Verschilscore[i], Formule)
     }
-    Resultaat <- as.numeric(evals(Formule, env = new.env())[[1]]$result)
+    Resultaat <- evals(Formule, env = new.env())[[1]]$result
+
+    if(!is.null(Resultaat)){
+      Resultaat <- as.numeric(Resultaat)
+    } else {
+      Resultaat = NA
+    }
 
     return(Resultaat)
   }


### PR DESCRIPTION
de functie vervangt stapsgewijs vorrwaardeID door verschilscore voor voorwaardeID. Maar als voorwaardeID (is een getal) van de ene voorwaarde voorkomt in de verschilscore van de andere voorwaarde krijg je rare dingen en krijg je error als resultaat doorgegeven wordt aan summarise-functie.
Tijdelijk oplossing: genereer een NA als er geen resultaat null is.