### PR TITLE
Unieke soortenlijst

### DIFF
--- a/R/geefInfoHabitatfiche.R
+++ b/R/geefInfoHabitatfiche.R
@@ -135,6 +135,7 @@ geefInfoHabitatfiche <-
           Habitattype = Habitattype,
           Criterium = Criterium,
           Indicator = Indicator,
+          Taxonlijstniveau = "indicator",
           Taxonlijsttype = "LSVIfiche",
           ConnectieLSVIhabitats = ConnectieLSVIhabitats
         ) %>%

--- a/R/geefSoortenlijst.R
+++ b/R/geefSoortenlijst.R
@@ -1,12 +1,15 @@
 #' @title Genereert soortenlijst(en) LSVI op basis van de opgegeven parameters
 #'
-#' @description Deze functie genereert soortenlijsten (met wetenschappelijke en Nederlandse namen) die gebruikt worden voor de bepaling van de Lokale Staat van Instandhouding van de opgegeven parameters.  In feite genereert ze een tabel met velden Versie, Habitattype, Habitatsubtype, Criterium, Indicator, evt. Beschrijving, WetNaam, WetNaamKort en NedNaam waarin de gespecificeerde parameters uitgeselecteerd zijn en waar voor andere parameters alle waarden uit de databank weergegeven zijn.
+#' @description Deze functie genereert soortenlijsten (met wetenschappelijke en Nederlandse namen) die gebruikt worden voor de bepaling van de Lokale Staat van Instandhouding van de opgegeven parameters.  In feite genereert ze een tabel met velden Versie, Habitattype, Habitatsubtype, WetNaam, WetNaamKort en NedNaam en evt. Criterium, Indicator en/of Beschrijving waarin de gespecificeerde parameters uitgeselecteerd zijn en waar voor andere parameters alle waarden uit de databank weergegeven zijn.
 #'
-#' Er zijn 2 opties: de taxa weergeven zoals in de habitatfiches (op soortniveau, genusniveau of hoger niveau, zoals het in de habitatfiches vermeld is) of alle taxa op lagere niveaus ook weergeven en dus bij soortengroepen alle mogelijke soorten van deze groep weergeven.  Deze opties kunnen opgegeven worden in de parameter Soortenlijsttype.
+#' Voor de vorm van de soortenlijst zijn er meerdere opties: een soortenlijst met alle soorten per habitat(sub)type, ofwel gegroepeerd per criterium, indicator of voorwaarde.  Dit kan opgegeven worden in de parameter Taxonlijstniveau.
+#' 
+#' Ook voor de weergave van de taxa zijn 2 opties: de taxa weergeven zoals in de habitatfiches (op soortniveau, genusniveau of hoger niveau, zoals het in de habitatfiches vermeld is) of alle taxa op lagere niveaus ook weergeven en dus bij soortengroepen alle mogelijke soorten van deze groep weergeven.  Deze opties kunnen opgegeven worden in de parameter Taxonlijsttype.
 #'
 #' @template Zoekparameters
 #'
 #' @inheritParams selecteerIndicatoren
+#' @param Taxonlijstniveau Geeft aan op welk niveau de soortenlijst gegroepeerd is (en welke niveaus weergegeven worden in de soortenlijst), de mogelijke waarden zijn 'habitattype', 'criterium', 'indicator' en 'voorwaarde'.  Default is 'habitattype'.
 #' @param Taxonlijsttype "LSVIfiche" betekent dat de taxonlijst van de habitatfiche wordt overgenomen, "alle" betekent dat alle soorten en alle taxonomische groepen worden weergegeven die volledig in de groepen vallen die aan de parameters voldoen.
 #'
 #' @return Deze functie geeft een tabel met velden Versie, Habitattype, Habitatsubtype, Criterium, Indicator, evt. Beschrijving, WetNaam, WetNaamKort en NedNaam (waarbij Beschrijving een omschrijving is voor een groep van taxa binnen eenzelfde indicator).  WetNaam is de volledige Latijnse naam inclusief auteursnaam, WetNaamKort geeft de verkorte naam zonder auteursnaam.
@@ -27,6 +30,8 @@ geefSoortenlijst <-
            Habitattype = "alle",
            Criterium = "alle",
            Indicator = "alle",
+           Taxonlijstniveau =
+             c("habitattype", "criterium", "indicator", "voorwaarde"),
            Taxonlijsttype = c("LSVIfiche", "alle"),
            ConnectieLSVIhabitats = ConnectiePool){
 
@@ -35,17 +40,34 @@ geefSoortenlijst <-
         inherits(ConnectieLSVIhabitats, "Pool"),
       msg = "Er is geen connectie met de databank met de LSVI-indicatoren"
     )
+    match.arg(Taxonlijstniveau)
     match.arg(Taxonlijsttype)
 
-    Selectiegegevens <-
-      selecteerIndicatoren(
-        Versie = Versie,
-        Habitatgroep = Habitatgroep,
-        Habitattype = Habitattype,
-        Criterium = Criterium,
-        Indicator = Indicator,
-        ConnectieLSVIhabitats = ConnectieLSVIhabitats)
-
+    if (Taxonlijstniveau[1] != "voorwaarde") {
+      Selectiegegevens <-
+        selecteerIndicatoren(
+          Versie = Versie,
+          Habitatgroep = Habitatgroep,
+          Habitattype = Habitattype,
+          Criterium = Criterium,
+          Indicator = Indicator,
+          ConnectieLSVIhabitats = ConnectieLSVIhabitats)
+    } else {
+      Selectiegegevens <-
+        geefInvoervereisten(
+          Versie = Versie,
+          Habitatgroep = Habitatgroep,
+          Habitattype = Habitattype,
+          Criterium = Criterium,
+          Indicator = Indicator,
+          ConnectieLSVIhabitats = ConnectieLSVIhabitats) %>%
+        select(
+          .data$Versie, .data$Habitattype, .data$Habitatsubtype,
+          .data$Criterium, .data$Indicator, .data$Beoordeling,
+          .data$Kwaliteitsniveau, .data$Voorwaarde, .data$TaxongroepId
+        )
+    }
+  
     SoortengroepIDs <- Selectiegegevens %>%
       select(.data$TaxongroepId) %>%
       distinct() %>%
@@ -55,20 +77,49 @@ geefSoortenlijst <-
     if (SoortengroepIDs$SoortengroepIDs == "") {
       stop("Voor de opgegeven argumenten is er geen soortenlijst")
     }
-
+  
     Soortenlijst <-
       geefSoortenlijstVoorIDs(
         Taxongroeplijst = SoortengroepIDs$SoortengroepIDs,
         Taxonlijsttype = Taxonlijsttype,
         ConnectieLSVIhabitats
       )
-
+  
     #soortgegevens aan selectiegegevens plakken
     SoortenlijstSelectie <- Selectiegegevens %>%
       left_join(
         Soortenlijst,
         by = ("TaxongroepId")
       )
+    
+    if (Taxonlijstniveau[1] == "voorwaarde") {
+      SoortenlijstSelectie <- SoortenlijstSelectie %>%
+        select(
+          -.data$Id
+        )
+    } else {
+      SoortenlijstSelectie <- SoortenlijstSelectie %>%
+        select(
+          .data$Versie, .data$Habitattype, .data$Habitatsubtype,
+          .data$Criterium, .data$Indicator, .data$Omschrijving,
+          .data$NbnTaxonVersionKey, .data$WetNaam, .data$NedNaam,
+          .data$WetNaamKort, .data$TaxonType
+        ) %>%
+        distinct()
+    }
+
+    if (Taxonlijstniveau[1] == "criterium") {
+      SoortenlijstSelectie <- SoortenlijstSelectie %>%
+        select(-.data$Indicator) %>%
+        filter(!is.na(.data$NbnTaxonVersionKey)) %>%
+        distinct()
+    }
+    if (Taxonlijstniveau[1] == "habitattype") {
+      SoortenlijstSelectie <- SoortenlijstSelectie %>%
+        select(-.data$Indicator, -.data$Criterium) %>%
+        filter(!is.na(.data$NbnTaxonVersionKey)) %>%
+        distinct()
+    }
 
     return(SoortenlijstSelectie)
 

--- a/R/geefSoortenlijst.R
+++ b/R/geefSoortenlijst.R
@@ -101,7 +101,8 @@ geefSoortenlijst <-
       SoortenlijstSelectie <- SoortenlijstSelectie %>%
         select(
           .data$Versie, .data$Habitattype, .data$Habitatsubtype,
-          .data$Criterium, .data$Indicator, .data$Omschrijving,
+          .data$Criterium, .data$Indicator, .data$TaxongroepId,
+          .data$Omschrijving,
           .data$NbnTaxonVersionKey, .data$WetNaam, .data$NedNaam,
           .data$WetNaamKort, .data$TaxonType
         ) %>%

--- a/man/geefSoortenlijst.Rd
+++ b/man/geefSoortenlijst.Rd
@@ -6,6 +6,7 @@
 \usage{
 geefSoortenlijst(Versie = "alle", Habitatgroep = "alle",
   Habitattype = "alle", Criterium = "alle", Indicator = "alle",
+  Taxonlijstniveau = c("habitattype", "criterium", "indicator", "voorwaarde"),
   Taxonlijsttype = c("LSVIfiche", "alle"),
   ConnectieLSVIhabitats = ConnectiePool)
 }
@@ -20,6 +21,8 @@ geefSoortenlijst(Versie = "alle", Habitatgroep = "alle",
 
 \item{Indicator}{De indicator waarvoor de gegevens uit de databank gehaald worden.  De mogelijke waarden kunnen opgevraagd worden via geefUniekeWaarden("Indicator", "Naam").}
 
+\item{Taxonlijstniveau}{Geeft aan op welk niveau de soortenlijst gegroepeerd is (en welke niveaus weergegeven worden in de soortenlijst), de mogelijke waarden zijn 'habitattype', 'criterium', 'indicator' en 'voorwaarde'.  Default is 'habitattype'.}
+
 \item{Taxonlijsttype}{"LSVIfiche" betekent dat de taxonlijst van de habitatfiche wordt overgenomen, "alle" betekent dat alle soorten en alle taxonomische groepen worden weergegeven die volledig in de groepen vallen die aan de parameters voldoen.}
 
 \item{ConnectieLSVIhabitats}{Connectie met de databank met indicatoren voor de LSVI van habitats, in te stellen d.m.v. functie connecteerMetLSVIdb.}
@@ -28,9 +31,11 @@ geefSoortenlijst(Versie = "alle", Habitatgroep = "alle",
 Deze functie geeft een tabel met velden Versie, Habitattype, Habitatsubtype, Criterium, Indicator, evt. Beschrijving, WetNaam, WetNaamKort en NedNaam (waarbij Beschrijving een omschrijving is voor een groep van taxa binnen eenzelfde indicator).  WetNaam is de volledige Latijnse naam inclusief auteursnaam, WetNaamKort geeft de verkorte naam zonder auteursnaam.
 }
 \description{
-Deze functie genereert soortenlijsten (met wetenschappelijke en Nederlandse namen) die gebruikt worden voor de bepaling van de Lokale Staat van Instandhouding van de opgegeven parameters.  In feite genereert ze een tabel met velden Versie, Habitattype, Habitatsubtype, Criterium, Indicator, evt. Beschrijving, WetNaam, WetNaamKort en NedNaam waarin de gespecificeerde parameters uitgeselecteerd zijn en waar voor andere parameters alle waarden uit de databank weergegeven zijn.
+Deze functie genereert soortenlijsten (met wetenschappelijke en Nederlandse namen) die gebruikt worden voor de bepaling van de Lokale Staat van Instandhouding van de opgegeven parameters.  In feite genereert ze een tabel met velden Versie, Habitattype, Habitatsubtype, WetNaam, WetNaamKort en NedNaam en evt. Criterium, Indicator en/of Beschrijving waarin de gespecificeerde parameters uitgeselecteerd zijn en waar voor andere parameters alle waarden uit de databank weergegeven zijn.
 
-Er zijn 2 opties: de taxa weergeven zoals in de habitatfiches (op soortniveau, genusniveau of hoger niveau, zoals het in de habitatfiches vermeld is) of alle taxa op lagere niveaus ook weergeven en dus bij soortengroepen alle mogelijke soorten van deze groep weergeven.  Deze opties kunnen opgegeven worden in de parameter Soortenlijsttype.
+Voor de vorm van de soortenlijst zijn er meerdere opties: een soortenlijst met alle soorten per habitat(sub)type, ofwel gegroepeerd per criterium, indicator of voorwaarde.  Dit kan opgegeven worden in de parameter Taxonlijstniveau.
+
+Ook voor de weergave van de taxa zijn 2 opties: de taxa weergeven zoals in de habitatfiches (op soortniveau, genusniveau of hoger niveau, zoals het in de habitatfiches vermeld is) of alle taxa op lagere niveaus ook weergeven en dus bij soortengroepen alle mogelijke soorten van deze groep weergeven.  Deze opties kunnen opgegeven worden in de parameter Taxonlijsttype.
 
 De parameters kunnen enkel de hieronder gespecifeerde waarden bevatten en moeten als string opgegeven worden.  Default is telkens 'alle', waarbij de soortenlijsten voor alle mogelijke waarden van die parameter weergegeven worden (m.a.w. er is geen selectie voor deze parameter).
 }


### PR DESCRIPTION
Aanpassingen aan geefSoortenlijst om het gebruiksgemak te vergroten (#78).

Belangrijkste voordelen:
- gebruiker kan kiezen op welk 'niveau' hij de soortenlijst wil: per habitat(sub)type, per criterium, per indicator of per voorwaarde (Eerder werd de lijst altijd gegeven per indicator, en dan kwamen er al dan niet gewenste 'dubbels' voor in de lijst.)
- het niveau 'voorwaarde' laat toe om de soortenlijstjes van de berekeningen rechtstreeks te controleren, geen gedoe meer met het opzoeken hiervan via de TaxongroepId onder geefInvoervereisten.  (Nadeel is wel dat die lijsten zeer lang kunnen zijn, bv. de volledige lijst bomen en struiken.)
- de soorten worden niet meer dubbel vermeld in de rapporten.

Nadeel:
- geefSoortenlijst(...) geeft default een andere uitvoer dan vroeger.  De meest op de vroegere situatie gelijkende uitvoer krijg je met geefSoortenlijst(..., Taxonlijstniveau = "indicator")