### PR TITLE
Aandeel grondvlak bomen niet-bos

### DIFF
--- a/R/s4_aandeel.R
+++ b/R/s4_aandeel.R
@@ -36,7 +36,7 @@ setMethod(
 
 
     if (nrow(alle_soorten) == 0) {
-      return(NA)
+      return(0)
     } else{
       teller_min <- sum(sleutelsoorten$WaardeMin, na.rm = TRUE)
       teller_max <- sum(sleutelsoorten$WaardeMax, na.rm = TRUE)

--- a/inst/tests/testthat/test_s4_Aandeel.R
+++ b/inst/tests/testthat/test_s4_Aandeel.R
@@ -1,0 +1,83 @@
+context("test s4_Aandeel")
+
+library(methods)
+
+describe("s4_Aandeel", {
+
+  it("Berekening BerekenWaarde gebeurt correct", {
+    expect_equal(
+      berekenWaarde(
+        new(
+          Class = "aandeel",
+          Kenmerken =
+            data.frame(
+              Kenmerk = c("A1", "B2", "C1", "D3", "E1"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMin = c(0, 1, 0, 1, 1),
+              WaardeMax = c(1, 3, 1, 3, 2),
+              Eenheid = "Grondvlak_ha",
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1,
+              SubTaxonId = 2,
+              stringsAsFactors = FALSE
+            )
+        )
+      ),
+      c(0.1, 1)
+    )
+    expect_equal(
+      berekenWaarde(
+        new(
+          Class = "aandeel",
+          Kenmerken =
+            data.frame(
+              Kenmerk = c("B2", "D3"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMin = 0.1,
+              WaardeMax = 0.1,
+              Eenheid = "Grondvlak_ha",
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1,
+              SubTaxonId = 2,
+              stringsAsFactors = FALSE
+            )
+        )
+      ),
+      c(0, 0)
+    )
+  })
+  it("Geen bomen in plot geeft resultaat 0", {
+      expect_equal(
+        berekenWaarde(
+          new(
+            Class = "aandeel",
+            Kenmerken =
+              data.frame(
+                Kenmerk = c("B2", "D3"),
+                TypeKenmerk = "soort_nbn",
+                WaardeMin = 0,
+                WaardeMax = 0.1,
+                Eenheid = "%",
+                stringsAsFactors = FALSE
+              ),
+            Soortengroep =
+              data.frame(
+                NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+                TaxonId = 1,
+                SubTaxonId = 2,
+                stringsAsFactors = FALSE
+              )
+          )
+        ),
+        0
+      )
+  })
+})


### PR DESCRIPTION
Als er bij een plot geen bomen aanwezig zijn, werd als resultaat voor het aandeel grondvlak van de sleutelsoorten NA gegeven.  Dit wordt nu vervangen door 0 -> dit geeft als resultaat ongunstig, maar het is zo wel duidelijk dat de berekening gebeurd is.
+ unittest toegevoegd om dit te testen