### PR TITLE
volgorde van habitatgroepen in rapport juist zetten

### DIFF
--- a/inst/LSVIrapport.Rmd
+++ b/inst/LSVIrapport.Rmd
@@ -58,7 +58,8 @@ Uitvoer <- NULL
 for (VersieRapportdeel in unique(Indicatoren$Versie)) {
   Uitvoer <- c(Uitvoer, paste("#", VersieRapportdeel, sep = ""))
   VersieIndicatoren <- Indicatoren %>%
-    filter(.data$Versie == VersieRapportdeel)
+    filter(.data$Versie == VersieRapportdeel) %>%
+    arrange(.data$Habitattype)
   for (Habitatgroep in unique(VersieIndicatoren$Habitatgroepnaam)) {
     Uitvoer <- c(Uitvoer, paste("##",Habitatgroep, sep = ""))
     Subset <- VersieIndicatoren %>%


### PR DESCRIPTION
De volgorde van de habitatgroepen (en habitattypes) in het rapport is juist gezet door de dataset in het rapport eerst te sorteren volgens habitattype. 