### PR TITLE
Aantal van dubbele soort

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     dplyr,
     lazyeval,
     methods,
-    odbc,
+    odbc (< 1.2.0),
     pander,
     pool,
     readr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     dplyr,
     lazyeval,
     methods,
-    odbc (< 1.2.0),
+    odbc,
     pander,
     pool,
     readr,

--- a/R/connecteerMetLSVIdb.R
+++ b/R/connecteerMetLSVIdb.R
@@ -49,6 +49,10 @@ connecteerMetLSVIdb <-
   assert_that(is.string(Databank))
   assert_that(is.string(Gebruiker))
   assert_that(is.string(Wachtwoord))
+  assert_that(
+    packageVersion("odbc") <= package_version("1.2.0"),
+    msg = "Het LSVI-package geeft problemen met de nieuwste versie van odbc. Installeer een oudere versie met het commando install.packages('http://cran.r-project.org/src/contrib/Archive/odbc/odbc_1.1.6.tar.gz', repos = NULL, type = 'source')" #nolint
+  )
 
   if (Gebruiker == "pc-eigenaar") {
     tryCatch(

--- a/R/maakConnectiePool.R
+++ b/R/maakConnectiePool.R
@@ -34,6 +34,10 @@ maakConnectiePool <-
   assert_that(is.string(Databank))
   assert_that(is.string(Gebruiker))
   assert_that(is.string(Wachtwoord))
+  assert_that(
+    packageVersion("odbc") <= package_version("1.2.0"),
+    msg = "Het LSVI-package geeft problemen met de nieuwste versie van odbc. Installeer een oudere versie met het commando install.packages('http://cran.r-project.org/src/contrib/Archive/odbc/odbc_1.1.6.tar.gz', repos = NULL, type = 'source')" #nolint
+  )
 
   if (Gebruiker == "pc-eigenaar") {
     tryCatch(

--- a/R/selecteerKenmerkenInOpname.R
+++ b/R/selecteerKenmerkenInOpname.R
@@ -78,7 +78,15 @@ selecteerKenmerkenInOpname <- #nolint
       kiesTaxonOfSubtaxons <-
         function(Dataset) {
           TaxonData <- Dataset %>%
-            filter(.data$TaxonId == .data$SubTaxonId)
+            filter(.data$TaxonId == .data$SubTaxonId) %>%
+            group_by(
+              .data$TaxonId, .data$Kenmerk, .data$TypeKenmerk, .data$SubTaxonId,
+              .data$Eenheid
+            ) %>%
+            summarise(
+              WaardeMin = 1.0 - prod(1.0 - .data$WaardeMin, na.rm = FALSE),
+              WaardeMax = 1.0 - prod(1.0 - .data$WaardeMax, na.rm = FALSE)
+            )
           if (nrow(TaxonData) < 1) {
             Dataset <- Dataset %>%
               group_by(.data$TaxonId) %>%

--- a/inst/tests/testthat/test_s4_Aantal.R
+++ b/inst/tests/testthat/test_s4_Aantal.R
@@ -528,4 +528,150 @@ describe("s4_Aantal", {
       2
     )
   })
+
+  it("Berekening gebeurt correct als een soort meermaals ingevoerd wordt", {
+    expect_equal(
+      berekenWaarde(
+        new(
+          Class = "aantal",
+          Kenmerken =
+            data.frame(
+              Rijnr = 1:5,
+              Kenmerk = c("A1", "B2", "C1", "D3", "C1"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMax = c(1, 0.8, 0.6, 0.4, 0.5),
+              WaardeMin = c(1, 0.8, 0.4, 0.4, 0.3),
+              Eenheid = "%",
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1:4,
+              SubTaxonId = 1:4,
+              stringsAsFactors = FALSE
+            ),
+          SubAnalyseVariabele = "bedekking",
+          SubRefMin = 0.5,
+          SubRefMax = 0.5,
+          SubOperator = ">="
+        )
+      ),
+      2
+    )
+    expect_equal(
+      berekenWaarde(
+        new(
+          Class = "aantal",
+          Kenmerken =
+            data.frame(
+              Rijnr = 1:5,
+              Kenmerk = c("A1", "B2", "C1", "D3", "C1"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMax = c(1, 0.8, 0.6, 0.4, 0.5),
+              WaardeMin = c(1, 0.8, 0.4, 0.4, 0.3),
+              Eenheid = "%",
+              Vegetatielaag = c(rep("moslaag", 3), rep("kruidlaag", "2")),
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1:4,
+              SubTaxonId = 1:4,
+              stringsAsFactors = FALSE
+            ),
+          SubAnalyseVariabele = "bedekking",
+          SubRefMin = 0.5,
+          SubRefMax = 0.5,
+          SubOperator = ">="
+        )
+      ),
+      2
+    )
+    expect_equal(
+      berekenWaarde(
+        new(
+          Class = "aantal",
+          Kenmerken =
+            data.frame(
+              Kenmerk = c("A1", "B2", "C1", "D3", "C1"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMin = 1,
+              WaardeMax = NA,
+              Eenheid = "ja/nee",
+              Vegetatielaag = c(rep("moslaag", 3), rep("kruidlaag", "2")),
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1:4,
+              SubTaxonId = 1:4,
+              stringsAsFactors = FALSE
+            )
+        )
+      ),
+      2
+    )
+    expect_warning(
+      berekenWaarde(
+        new(
+          Class = "aantal",
+          Kenmerken =
+            data.frame(
+              ID = 1:5,
+              Kenmerk = c("A1", "B2", "C1", "D3", "C1"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMin = 1,
+              WaardeMax = NA,
+              Eenheid = "ja/nee",
+              Vegetatielaag = c(rep("moslaag", 3), rep("kruidlaag", "2")),
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1:4,
+              SubTaxonId = 1:4,
+              stringsAsFactors = FALSE
+            ),
+          SubAnalyseVariabele = "bedekking",
+          SubRefMin = 0.5,
+          SubRefMax = 0.5,
+          SubOperator = ">="
+        )
+      )
+    )
+    expect_equal(
+      berekenWaarde(
+        new(
+          Class = "aantal",
+          Kenmerken =
+            data.frame(
+              ID = 1:5,
+              Kenmerk = c("A1", "B2", "C1", "D3", "C1"),
+              TypeKenmerk = "soort_nbn",
+              WaardeMin = 1,
+              WaardeMax = NA,
+              Eenheid = "ja/nee",
+              Vegetatielaag = c(rep("moslaag", 3), rep("kruidlaag", "2")),
+              stringsAsFactors = FALSE
+            ),
+          Soortengroep =
+            data.frame(
+              NbnTaxonVersionKey = c("A1", "B1", "C1", "E1"),
+              TaxonId = 1:4,
+              SubTaxonId = 1:4,
+              stringsAsFactors = FALSE
+            ),
+          SubAnalyseVariabele = "bedekking",
+          SubRefMin = 0.5,
+          SubRefMax = 0.5,
+          SubOperator = ">="
+        )
+      ),
+      c(0, 2)
+    )
+  })
 })

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,7 +5,8 @@ build:
         code: |
           apt-get update
           apt-get install -y libgeos-dev
-          Rscript -e "install.packages(c('odbc', 'pool', 'rgbif', 'pander'))"
+          Rscript -e "install.packages(c('pool', 'rgbif', 'pander'))"
+          Rscript -e "install.packages('http://cran.r-project.org/src/contrib/Archive/odbc/odbc_1.1.6.tar.gz', repos = NULL, type = 'source')"
     - inbobmk/r-check
     - inbobmk/r-coverage
     - jimhester/r-lint


### PR DESCRIPTION
Deze aanpassing zorgt ervoor dat de berekening van het aantal soorten correct gebeurt als er een soort tweemaal ingevoerd is (bv. in verschillende vegetatielagen): de bedekking van de soort wordt 'opgeteld' via de formule van Fischer, en daarna wordt evt. geselecteerd op basis van de subvoorwaarde (bv. minimale bedekking).  De soort wordt dus geen tweemaal meer geteld, zoals eerst het geval was.