### PR TITLE
probleem met odbc

### DIFF
--- a/R/connecteerMetLSVIdb.R
+++ b/R/connecteerMetLSVIdb.R
@@ -49,10 +49,6 @@ connecteerMetLSVIdb <-
   assert_that(is.string(Databank))
   assert_that(is.string(Gebruiker))
   assert_that(is.string(Wachtwoord))
-  assert_that(
-    packageVersion("odbc") <= package_version("1.2.0"),
-    msg = "Het LSVI-package geeft problemen met de nieuwste versie van odbc. Installeer een oudere versie met het commando install.packages('http://cran.r-project.org/src/contrib/Archive/odbc/odbc_1.1.6.tar.gz', repos = NULL, type = 'source')" #nolint
-  )
 
   if (Gebruiker == "pc-eigenaar") {
     tryCatch(

--- a/R/geefInfoHabitatfiche.R
+++ b/R/geefInfoHabitatfiche.R
@@ -93,7 +93,7 @@ geefInfoHabitatfiche <-
         AS Beschrijving_naSoorten,
       cast(Indicator_habitat.Maatregelen AS nvarchar(510)) AS Maatregelen,
       cast(Indicator_habitat.Opmerkingen AS nvarchar(830)) AS Opmerkingen,
-      cast(Indicator_habitat.Referenties AS nvarchar(260)) AS Referenties,
+      cast(Indicator_habitat.Referenties AS nvarchar(290)) AS Referenties,
       Indicator_habitat.TaxongroepId
       FROM Indicator_habitat
       WHERE Indicator_habitat.Id in ('%s')",
@@ -115,7 +115,7 @@ geefInfoHabitatfiche <-
     query_beoordelingsfiche <- sprintf(
       "SELECT Indicator_beoordeling.Id AS Indicator_beoordelingID,
       Criterium.Naam AS Criterium, Indicator.Naam As Indicator,
-      cast(Indicator_beoordeling.Opmerkingen AS nvarchar(710)) AS Opmerkingen,
+      cast(Indicator_beoordeling.Opmerkingen AS nvarchar(900)) AS Opmerkingen,
       cast(Indicator_beoordeling.Referenties AS nvarchar(150)) AS Referenties,
       Beoordeling.Kwaliteitsniveau,
       cast(Beoordeling.Beoordeling_letterlijk AS nvarchar(360))

--- a/R/geefInvoervereisten.R
+++ b/R/geefInvoervereisten.R
@@ -143,7 +143,8 @@ geefInvoervereisten <- function(Versie = "alle",
   query_lsvi_info <-
     sprintf("SELECT Indicator_beoordeling.Id AS Indicator_beoordelingID,
             Criterium.Naam AS Criterium, Indicator.Naam AS Indicator,
-            Beoordeling.Beoordeling_letterlijk AS Beoordeling,
+            cast(Beoordeling.Beoordeling_letterlijk AS nvarchar(360))
+              AS Beoordeling,
             Beoordeling.Kwaliteitsniveau,
             Indicator_beoordeling.Belang,
             Beoordeling.Id as BeoordelingID
@@ -270,7 +271,7 @@ geefInvoervereisten <- function(Versie = "alle",
             LijstItem.Gemiddelde AS Invoergemiddelde,
             Lijstitem.Bovengrens AS Invoerbovengrens,
             Voorwaarde.TaxongroepId,
-            Taxongroep.Omschrijving AS TaxongroepNaam,
+            cast(Taxongroep.Omschrijving AS nvarchar(90)) AS TaxongroepNaam,
             Studiegroep.Naam AS Studiegroepnaam,
             Studiegroep.LijstNaam as Studielijstnaam,
             StudieItem.Waarde As Studiewaarde,
@@ -368,7 +369,7 @@ geefInvoervereisten <- function(Versie = "alle",
       LSVIinfo,
       by = c("Indicator_beoordelingID" = "Indicator_beoordelingID")
     ) %>%
-    mutate_(Indicator_beoordelingID = ~NULL) %>%
+    mutate(Indicator_beoordelingID = NULL) %>%
     left_join(BasisVoorwaarden, by = c("BeoordelingID" = "BeoordelingID")) %>%
     left_join(Voorwaardeinfo, by = c("VoorwaardeID" = "VoorwaardeID"))
 

--- a/R/geefSoortenlijstVoorIDs.R
+++ b/R/geefSoortenlijstVoorIDs.R
@@ -82,13 +82,13 @@ geefSoortenlijstVoorIDs <-
         (
           SELECT Tg.Id AS TaxongroepId,
             Tg.Id AS TaxonsubgroepId,
-            Tg.Omschrijving
+            cast(Tg.Omschrijving AS nvarchar(90)) AS Omschrijving
           FROM Taxongroep Tg
           WHERE Tg.Id in (%s)
         UNION ALL
           SELECT Groepen.TaxongroepId,
             Tg2.Id AS TaxonsubgroepId,
-          Tg2.Omschrijving
+            cast(Tg2.Omschrijving AS nvarchar(90)) AS Omschrijving
           FROM Groepen
             INNER JOIN TaxongroepTaxongroep AS TgTg
             ON Groepen.TaxonsubgroepId = TgTg.TaxongroepParentId

--- a/R/maakConnectiePool.R
+++ b/R/maakConnectiePool.R
@@ -34,10 +34,6 @@ maakConnectiePool <-
   assert_that(is.string(Databank))
   assert_that(is.string(Gebruiker))
   assert_that(is.string(Wachtwoord))
-  assert_that(
-    packageVersion("odbc") <= package_version("1.2.0"),
-    msg = "Het LSVI-package geeft problemen met de nieuwste versie van odbc. Installeer een oudere versie met het commando install.packages('http://cran.r-project.org/src/contrib/Archive/odbc/odbc_1.1.6.tar.gz', repos = NULL, type = 'source')" #nolint
-  )
 
   if (Gebruiker == "pc-eigenaar") {
     tryCatch(

--- a/R/selecteerIndicatoren.R
+++ b/R/selecteerIndicatoren.R
@@ -155,7 +155,8 @@ selecteerIndicatoren <-
           SELECT Habitatgroep.Naam AS Habitatgroepnaam,
             Ht1.Code AS Habitattype, Ht1.Naam AS Habitatnaam,
             Ht1.Code AS Habitatsubtype, Ht1.Naam AS Habitatsubtypenaam,
-            Ht1.Omschrijving AS HabitatsubtypeOmschrijving,
+            cast(Ht1.Omschrijving AS nvarchar(10))
+              AS HabitatsubtypeOmschrijving,
             Ht1.Id AS HabitattypeId, Ht1.Id AS HabitatsubtypeId
           FROM Habitattype AS Ht1 INNER JOIN Habitatgroep
           ON Ht1.HabitatgroepId = Habitatgroep.Id
@@ -164,7 +165,8 @@ selecteerIndicatoren <-
           SELECT Habitatselectie.Habitatgroepnaam,
             Habitatselectie.Habitattype, Habitatselectie.Habitatnaam,
             Ht2.Code AS Habitatsubtype, Ht2.Naam AS Habitatsubtypenaam,
-            Ht2.Omschrijving AS HabitatsubtypeOmschrijving,
+            cast(Ht2.Omschrijving AS nvarchar(10))
+              AS HabitatsubtypeOmschrijving,
             Habitatselectie.HabitattypeId, Ht2.Id AS HabitatsubtypeId
           FROM Habitatselectie INNER JOIN Habitattype AS Ht2
           ON Habitatselectie.HabitatsubtypeId = Ht2.ParentId

--- a/data-raw/migratieSQLserverSQLite.R
+++ b/data-raw/migratieSQLserverSQLite.R
@@ -60,7 +60,7 @@ migratieSQLserverSQLite <-
         cast(Beschrijving_naSoorten AS nvarchar(200)) AS Beschrijving_naSoorten,
         cast(Maatregelen AS nvarchar(510)) AS Maatregelen,
         cast(Opmerkingen AS nvarchar(830)) AS Opmerkingen,
-        cast(Referenties AS nvarchar(260)) AS Referenties,
+        cast(Referenties AS nvarchar(290)) AS Referenties,
         TaxongroepId, HabitattypeId, VersieId
         FROM Indicator_habitat
         WHERE HabitattypeId in (%s) and VersieId in (%s)",
@@ -91,7 +91,7 @@ migratieSQLserverSQLite <-
       ConnectiePool,
       sprintf(
         "SELECT Id, IndicatorId, HabitattypeId, VersieId,
-        cast(Opmerkingen AS nvarchar(710)) AS Opmerkingen,
+        cast(Opmerkingen AS nvarchar(900)) AS Opmerkingen,
         cast(Referenties AS nvarchar(150)) AS Referenties, Belang
         FROM Indicator_beoordeling
         WHERE Id in (%s)",
@@ -266,7 +266,7 @@ migratieSQLserverSQLite <-
       ConnectiePool,
       sprintf(
         "SELECT Id, Naam,
-        cast(Omschrijving AS nvarchar(70)) AS Omschrijving, AfkomstGegevens
+        cast(Omschrijving AS nvarchar(90)) AS Omschrijving, AfkomstGegevens
         FROM Taxongroep
         WHERE Id in (%s)",
         TaxongroepId

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,8 +5,7 @@ build:
         code: |
           apt-get update
           apt-get install -y libgeos-dev
-          Rscript -e "install.packages(c('pool', 'rgbif', 'pander'))"
-          Rscript -e "install.packages('http://cran.r-project.org/src/contrib/Archive/odbc/odbc_1.1.6.tar.gz', repos = NULL, type = 'source')"
+          Rscript -e "install.packages(c('odbc', 'pool', 'rgbif', 'pander'))"
     - inbobmk/r-check
     - inbobmk/r-coverage
     - jimhester/r-lint


### PR DESCRIPTION
Door de aanpassing van het package odbc dook er ineens een foutmelding op bij queries waar velden van datatype nvarchar(max) gebruikt werden, als deze niet als laatste veld vermeld waren in de query.  Deze pull request vangt dit probleem op door telkens nvarchar(max) te casten naar een nvarchar met grootte die groter is dan het record met de langste string.