### PR TITLE
meer informatieve warning bij ontbreken meting

### DIFF
--- a/R/berekenLSVIbasis.R
+++ b/R/berekenLSVIbasis.R
@@ -522,9 +522,13 @@ berekenLSVIbasis <- #nolint
         if (nrow(WarningMeting) > 0) {
           warning(
             sprintf(
-              "De waarde voor de voorwaarde(n) met VoorwaardeID %s kunnen niet berekend worden voor opname(n) %s. Geef de waarde voor deze voorwaarde rechtstreeks in als input van de functie 'berekenLSVIBasis' via 'Data_voorwaarden'",  #nolint
+              "De waarde(n) voor de voorwaarde(n) %s (VoorwaardeID %s) kunnen niet berekend worden voor opname(n) %s. Geef de waarde voor deze voorwaarde rechtstreeks in als input van de functie 'berekenLSVIBasis' via tabel 'Data_voorwaarden' (zie ?berekenLSVIbasis voor meer info). Vermeld hierbij Criterium = %s, Indicator = %s en Voorwaarde = %s.",  #nolint
+              str_c(unique(WarningMeting$Voorwaarde), collapse = ", "),
               str_c(unique(WarningMeting$VoorwaardeID), collapse = ", "),
-              str_c(unique(WarningMeting$ID), collapse = ", ")
+              str_c(unique(WarningMeting$ID), collapse = ", "),
+              str_c(unique(WarningMeting$Criterium), collapse = ", "),
+              str_c(unique(WarningMeting$Indicator), collapse = ", "),
+              str_c(unique(WarningMeting$Voorwaarde), collapse = ", ")
             )
           )
         }


### PR DESCRIPTION
warning bij ontbreken van ingevoerde voorwaarde voor s4-klasse meting meer informatief gemaakt

In verband met issue #74 is de foutboodschap alvast meer informatief gemaakt, met opgave van criteriumnaam, indicatornaam en voorwaardenaam van de voorwaarde in kwestie, zodat de gebruiker deze info niet meer actief moet gaan opzoeken, maar direct deze voorwaarde kan aanvullen in Data_voorwaarden (evt. door de betreffende info uit Data_soortenKenmerken te kopiëren en aan te vullen met de info uit de foutmelding).