### PR TITLE
overbodig assignment naar .GlobalEnv verwijderd in connecteerMetLSVIdb

### DIFF
--- a/R/connecteerMetLSVIdb.R
+++ b/R/connecteerMetLSVIdb.R
@@ -61,14 +61,12 @@ connecteerMetLSVIdb <-
           Database = Databank,
           Trusted_Connection = "True",
           encoding = "UTF-8"
-        ),
-        envir = .GlobalEnv
+        )
       ),
       error = function(e) {
         assign(
           "ConnectieLSVIhabitats",
-          connecteerMetLSVIlite(),
-          envir = .GlobalEnv
+          connecteerMetLSVIlite()
         )
       }
     )

--- a/R/connecteerMetLSVIdb.R
+++ b/R/connecteerMetLSVIdb.R
@@ -51,6 +51,7 @@ connecteerMetLSVIdb <-
   assert_that(is.string(Wachtwoord))
 
   if (Gebruiker == "pc-eigenaar") {
+    huidige_env <- as.environment(-1)
     tryCatch(
       assign(
         "ConnectieLSVIhabitats",
@@ -66,7 +67,8 @@ connecteerMetLSVIdb <-
       error = function(e) {
         assign(
           "ConnectieLSVIhabitats",
-          connecteerMetLSVIlite()
+          connecteerMetLSVIlite(),
+          envir = huidige_env
         )
       }
     )


### PR DESCRIPTION
Het package drake geeft problemen als iets toegewezen wordt aan de 'global environment', en in connecteerMetLSVIdb was die toewijzing overbodig, dus deze is verwijderd (zonder implicaties voor gebruikers).