### PR TITLE
eenzelfde voorwaarde maar eenmaal doorgeven bij geefInvoervereisten

### DIFF
--- a/R/geefInvoervereisten.R
+++ b/R/geefInvoervereisten.R
@@ -371,7 +371,8 @@ geefInvoervereisten <- function(Versie = "alle",
     ) %>%
     mutate(Indicator_beoordelingID = NULL) %>%
     left_join(BasisVoorwaarden, by = c("BeoordelingID" = "BeoordelingID")) %>%
-    left_join(Voorwaardeinfo, by = c("VoorwaardeID" = "VoorwaardeID"))
+    left_join(Voorwaardeinfo, by = c("VoorwaardeID" = "VoorwaardeID")) %>%
+    distinct()
 
   return(Invoervereisten)
 }

--- a/man/geefUniekeWaarden.Rd
+++ b/man/geefUniekeWaarden.Rd
@@ -22,7 +22,7 @@ verschillende waarden uit de gespecifieerde tabel.
 }
 \description{
 Deze hulpfunctie geeft een vector met alle verschillende
-waarden die een gespecifieerd veld van een gespecifieerde tabel in de
+waarden die in een gespecificeerd veld van een gespecificeerde tabel in de
 databank met LSVI-indicatoren staan, voorafgegaan door de (toegevoegde)
 waarde "alle".  Deze functie wordt in verschillende functies van het package
 gebruikt om de invoer van parameters te controleren (waar de mogelijke


### PR DESCRIPTION
Eenzelfde voorwaarde maar eenmaal doorgeven bij geefInvoervereisten, ook als ze tweemaal nodig is om de indicator te berekenen.