### PR TITLE
Overbodige code verwijderen

### DIFF
--- a/R/deselecteerKenmerkenInOpname.R
+++ b/R/deselecteerKenmerkenInOpname.R
@@ -77,51 +77,10 @@ deselecteerKenmerkenInOpname <-
         distinct()
 
       return(Resultaat)
-    }
-
-    if (!identical(SubAnalyseVariabele, character(0)) &
-        SubAnalyseVariabele == "bedekking") {
-      Resultaat <- Resultaat %>%
-        mutate(
-          RefMin = SubRefMin,
-          RefMax = SubRefMax,
-          Operator = SubOperator,
-          Rijnr = row_number(.data$Kenmerk)
-        )
-
-      SubStatusberekening <-
-        berekenStatus(
-          Resultaat[
-            , c(
-              "Rijnr",
-              "RefMin",
-              "RefMax",
-              "Operator",
-              "WaardeMin",
-              "WaardeMax"
-            )
-          ]
-        )
-
-      Resultaat <- Resultaat %>%
-        left_join(
-          SubStatusberekening,
-          by = c("Rijnr")
-        ) %>%
-        mutate(
-          Rijnr = NULL
-        ) %>%
-        filter(
-          .data$Status == TRUE
-        ) %>%
-        distinct()
-
     } else {
       stop(
         paste(
-          "Onbekende subanalysevariabele",
-          SubAnalyseVariabele,
-          "in de indicatorendatabank.  Meld deze fout aan de beheerder van dit package."  #nolint
+          "Fout in de indicatorendatabank: een analysevariabele met achtervoegsel 'Excl' bevat een subanalysevariabele en dit wordt niet ondersteund in het script.  Meld deze fout aan de beheerder van dit package."  #nolint
         )
       )
     }

--- a/R/logDatabankfouten.R
+++ b/R/logDatabankfouten.R
@@ -122,7 +122,7 @@ logDatabankfouten <- function(ConnectieLSVIhabitats = NULL) {
       "SELECT tgtg.TaxongroepParentId AS tg, tgtg.TaxongroepChildId AS tgChild
       FROM TaxongroepTaxongroep tgtg"
     ) %>%
-    count(tg) %>%
+    count(.data$tg) %>%
     filter(n == 2)
 
   Voorwaarden <- OnbekendeAV %>%

--- a/vignettes/Berekeningen.Rmd
+++ b/vignettes/Berekeningen.Rmd
@@ -148,7 +148,7 @@ Deze formule geeft uiteraard maar een benaderende waarde die minder accuraat is 
 
 Bij de analysevariabele `bedekkingExcl` gaat de voorwaarde over de totale bedekking van de soorten/kenmerken die niet in een lijst voorkomen, bv. alle soorten behalve de sleutelsoorten.
 
-Bij voorwaarden met deze analysevariabele worden de soorten/kenmerken geselecteerd op basis van een functie `deselecteerKenmerkenInOpname`, die in de opname van de gebruiker de soorten/kenmerken schrapt die in de taxonlijst/studielijst voorkomen.  Verder gebeurt de berekening analoog aan deze van de analysevariabele `bedekking`
+Bij voorwaarden met deze analysevariabele worden de soorten/kenmerken geselecteerd op basis van een functie `deselecteerKenmerkenInOpname`, die in de opname van de gebruiker de soorten/kenmerken schrapt die in de taxonlijst/studielijst voorkomen (en de overblijvende soorten/kenmerken vormen de selectie).  Verder gebeurt de berekening analoog aan deze van de analysevariabele `bedekking`: met de formule van Fisher wordt de totale bedekking van deze selectie berekend.
 
 ##bedekkingLaag
 
@@ -191,7 +191,7 @@ De analysevariabele `maxBedekking2s` is gelijkaardig aan `maxBedekking` met als 
 
 Bij de analysevariabele `maxBedekkingExcl` gaat de voorwaarde over de maximale bedekking van de soorten/kenmerken die niet in een lijst voorkomen, bv. alle soorten behalve de sleutelsoorten.
 
-Bij voorwaarden met deze analysevariabele worden de soorten/kenmerken geselecteerd op basis van een functie `deselecteerKenmerkenInOpname`, die in de opname van de gebruiker de soorten/kenmerken schrapt die in de taxonlijst/studielijst voorkomen.  Verder gebeurt de berekening analoog aan deze van de analysevariabele `maxBedekking`
+Bij voorwaarden met deze analysevariabele worden de soorten/kenmerken geselecteerd op basis van een functie `deselecteerKenmerkenInOpname`, die in de opname van de gebruiker de soorten/kenmerken schrapt die in de taxonlijst/studielijst voorkomen (en de overblijvende soorten/kenmerken vormen de selectie).  Verder gebeurt de berekening analoog aan deze van de analysevariabele `maxBedekking`: de soort of kenmerk met maximale bedekking wordt geselecteerd uit de selectie.
 
 ##aandeel
 


### PR DESCRIPTION
Deze PR is een oplossing voor issue #181 om de overbodige code in deselecteerKenmerkenInOpname te verwijderen.  Bijkomend is de informatie over deselecteerKenmerkenInOpname verduidelijkt in het vignet berekeningen.